### PR TITLE
fix for compatibility with clang++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
   LINKER	?=	ar rcs
   COMPILER	?=	g++
 
-  CONFIG	=	-W -Wall -fPIC -std=gnu++03				\
+  CONFIG	=	-W -Wall -Werror -fPIC -std=gnu++98			\
 			-D_GLIBCXX_USE_CXX11_ABI=0 -Wno-unused-result
 
   DEBUG		=	-O0 -g -g3 -ggdb -DBUNNY_ALLOCATOR_DEACTIVATED

--- a/src/deps/abs/NetUnix.cpp
+++ b/src/deps/abs/NetUnix.cpp
@@ -172,23 +172,29 @@ bool			bpt::NetAbs::NetUnix::Select(Socket			max,
     if (select(max, &fdread, &fdwrite, &fdexcept, NULL) == -1)
       return (false);
   if (read != NULL)
+  {
     for (it = read->state.begin(); it != read->state.end(); ++it)
       if (FD_ISSET(it->first, &fdread))
 	it->second = true;
       else
 	it->second = false;
+  }
   if (write != NULL)
+  {
     for (it = write->state.begin(); it != write->state.end(); ++it)
       if (FD_ISSET(it->first, &fdwrite))
 	it->second = true;
       else
 	it->second = false;
+  }
   if (except != NULL)
+  {
     for (it = except->state.begin(); it != except->state.end(); ++it)
       if (FD_ISSET(it->first, &fdexcept))
 	it->second = true;
       else
 	it->second = false;
+  }
   return (true);
 }
 

--- a/src/graphics/vectfont.cpp
+++ b/src/graphics/vectfont.cpp
@@ -5,6 +5,11 @@
 
 #include		"lapin_private.h"
 
+/*
+ * unused yet, clang is stricter than gcc therefore does not compile because
+ * of this unused variable
+ */
+#if 0
 /* 20 * 20 */
 const t_bunny_letter	gl_vector_font[LAST_BUNNY_FONT] =
   {
@@ -364,3 +369,4 @@ const t_bunny_letter	gl_vector_font[LAST_BUNNY_FONT] =
     }
   };
 
+#endif /* !0 */


### PR DESCRIPTION
clang++ doesn't support "gnu++03"  (for gnu c++ 98) use "gnu++98" instead which is supported by both g++ and clang++
clang is more strict than gcc (and add -Werror flag)



