### PR TITLE
Various little fix and fix compilation with newer opencv

### DIFF
--- a/src/camera/headtrack.cpp
+++ b/src/camera/headtrack.cpp
@@ -9,6 +9,10 @@
 #include		<unistd.h>
 #include		"lapin_private.h"
 
+#ifndef CV_BGR2GRAY
+# define CV_BGR2GRAY cv::COLOR_BGR2GRAY
+#endif /* !CV_BGR2GRAY */
+
 struct			FileDumper
 {
   static const std::string haar;

--- a/src/configuration/expr/read_function_call.cpp
+++ b/src/configuration/expr/read_function_call.cpp
@@ -64,7 +64,7 @@ bool			expr_read_function_call(const char	*code,
 	    prev = calltype;
 	  else if (prev != calltype)
 	    scream_error_if
-	      (return (NULL), BE_SYNTAX_ERROR,
+	      (return (false), BE_SYNTAX_ERROR,
 	       "Mixing named parameters with order "
 	       "parameters is impossible on line %d",
 	       "ressource,configuration,syntax",

--- a/src/history/get_frame.cpp
+++ b/src/history/get_frame.cpp
@@ -12,7 +12,6 @@ const void	*bunny_history_get_frame(t_bunny_history	*h,
 {
   struct bunny_history	*his = (struct bunny_history*)h;
   std::map<size_t, void*>::iterator it;
-  std::pair<size_t, void*> tmp;
 
   if ((it = his->history.find(tim)) == his->history.end())
     {

--- a/src/tilemap/load_tmx.cpp
+++ b/src/tilemap/load_tmx.cpp
@@ -14,7 +14,7 @@ static bool		assert_node_value(t_bunny_configuration			*cnf,
   const char		*tmp;
 
   if (!bunny_configuration_getf_string(cnf, &tmp, addr))
-    scream_error_if(return (NULL), EINVAL, "", "tilemap");
+    scream_error_if(return (false), EINVAL, "", "tilemap");
   return (strcmp(tmp, val) == 0);
 }
 

--- a/src/window/list_monitor.cpp
+++ b/src/window/list_monitor.cpp
@@ -21,7 +21,7 @@ static bool			get_output(char			*buf,
   size_t			l;
 
   if ((fil = popen(cmd, "r")) == NULL)
-    return (NULL);
+    return (false);
   l = 0;
   do
     {


### PR DESCRIPTION
This PR include:
- add a define for CV_BGR2GRAY (to cv::COLOR_BGR2GRAY) because it doesn't exist anymore in OpenCV (commit bef3a02)
- fix various incorrect return type, eg: `return NULL` in  bool fnc (commit 3bcf76b)
- remove unused 'tmp' variable in bunny_history_get_frame (commit 3bcf76b)