### PR TITLE
MAJ Mergeconf et changement de prototype de bunny_configuration_resolve_path()

### DIFF
--- a/bcc
+++ b/bcc
@@ -7,3 +7,4 @@ then
 fi
 
 gcc "$@" -std=gnu11 -llapin$DEBUG -lsfml-graphics -lsfml-audio -lsfml-window -lsfml-system -lGL -lstdc++ -lm -ldl -lpthread -lopencv_imgproc -lopencv_highgui -lopencv_objdetect -lopencv_video -lopencv_videoio -lopencv_core -lavcall -lusb -ludev
+echo gcc "$@" -std=gnu11 -llapin$DEBUG -lsfml-graphics -lsfml-audio -lsfml-window -lsfml-system -lGL -lstdc++ -lm -ldl -lpthread -lopencv_imgproc -lopencv_highgui -lopencv_objdetect -lopencv_video -lopencv_videoio -lopencv_core -lavcall -lusb -ludev

--- a/include/lapin/configuration.h
+++ b/include/lapin/configuration.h
@@ -508,7 +508,9 @@ t_bunny_configuration_type bunny_which_format(const char				*file);
 
 void			bunny_configuration_push_path(const char			*file);
 void			bunny_configuration_pop_path(void);
-const char		*bunny_configuration_resolve_path(const char			*str);
+bool			bunny_configuration_resolve_path(const char			*str,
+							 char				*buffer,
+							 int				size_buffer);
 
 bool			bunny_configuration_read_time(const t_bunny_configuration	*cnf,
 						      const char			*fld,

--- a/misc/programs/toys/path_resolve/src/main.c
+++ b/misc/programs/toys/path_resolve/src/main.c
@@ -12,10 +12,14 @@ int		main(int		argc,
 		     char		**argv)
 {
   int		i;
+  char		buffer[1024];
 
   bunny_configuration_push_path(".");
   for (i = 1; i + 1 < argc; ++i)
     bunny_configuration_push_path(argv[i]);
-  printf("Resolved path is: %s.\n", bunny_configuration_resolve_path(argv[i]));
+  if (bunny_configuration_resolve_path(argv[i], buffer, sizeof(buffer)))
+    printf("Resolved path is: %s.\n", buffer);
+  else
+    printf("No resolved path found.");
   return (EXIT_SUCCESS);
 }

--- a/misc/programs/utils/mergeconf/Makefile
+++ b/misc/programs/utils/mergeconf/Makefile
@@ -22,7 +22,7 @@
   ## Rules ------------------------------------------------------------------
   all:		bin
   bin:		$(OBJ)
-		@gcc $(OBJ) -o $(BIN) $(LIBPATH) $(LIB)
+		@gcc $(OBJ) -g -ggdb -o $(BIN) $(LIBPATH) $(LIB)
 		@echo "[OUT] " $(BIN)
 		@echo $(BIN) | tr '[:lower:]' '[:upper:]'
   .c.o:

--- a/misc/programs/utils/mergeconf/src/main.c
+++ b/misc/programs/utils/mergeconf/src/main.c
@@ -139,6 +139,12 @@ int			main(int					argc,
 	  if (i < argc && (argv[i][0] == '-' || argv[i][0] == '!' || argv[i][0] == '+'))
 	    i -= 1;
 	}
+      else if (!strcmp("-I", argv[i]))
+	{
+	  i += 1;
+	  if (i < argc && argv[i][0] != '-' && argv[i][0] != '!' && argv[i][0] != '+')
+	    bunny_configuration_push_path(argv[i]);
+	}
       else if (!strcmp("-m", argv[i]))
 	{
 	  for (i += 1; i < argc && argv[i][0] != '-' && argv[i][0] != '!' && argv[i][0] != '+'; ++i)
@@ -210,6 +216,7 @@ int			main(int					argc,
 
   if (oformat == BC_CUSTOM)
     oformat = BC_DABSIC;
+  //  fprintf(stderr, "%d\n", nbr_inputs);
   if (argc == 1 || (iformat == BC_CUSTOM && nbr_inputs == 0))
     {
       fprintf

--- a/misc/programs/utils/mergeconf/src/main.c
+++ b/misc/programs/utils/mergeconf/src/main.c
@@ -225,6 +225,7 @@ int			main(int					argc,
 	 "\n"
 	 "  -if [format]\tSpecify the input format when using stdin\n"
 	 "  -of [format]\tSpecify the output format when using stdout. Default is Dabsic.\n"
+	 "  -I [path]   \tSpecify an additional path for include or other files to be load.\n"
 	 "  -i [files]+ \tSpecify input files. Cannot combine with if.\n"
 	 "  -o [files]+ \tSpecify output files. Cannot combine with of.\n"
 	 "  -m [address=value]+ Specifiy field value.\n"

--- a/src/configuration/handle_directive.cpp
+++ b/src/configuration/handle_directive.cpp
@@ -138,9 +138,9 @@ Decision		_bunny_handle_directive(const char		*code,
   dirconf.GetString(&tmp, (SmallConf*)bunny_configuration_get_root(node), (SmallConf*)node, NULL, NULL);
 
   std::string		filepath = tmp;
-  const char		*res;
+  char			res[1024];
 
-  if ((res = bunny_configuration_resolve_path(filepath.c_str())) == NULL)
+  if (!bunny_configuration_resolve_path(filepath.c_str(), res, sizeof(res)))
     scream_error_if
       (return (BD_ERROR), BE_SYNTAX_ERROR, PATTERN,
        "ressource,configuration,syntax",

--- a/src/configuration/parsing.cpp
+++ b/src/configuration/parsing.cpp
@@ -619,9 +619,9 @@ bool			readvalue(const char			*code,
   // @suivi d'un chemin.
   else if (readpath(code, i, &buffer[0], sizeof(buffer)))
     {
-      const char	*tmp = bunny_configuration_resolve_path(&buffer[0]);
+      char	tmp[1024];
 
-      if (tmp == NULL)
+      if (bunny_configuration_resolve_path(&buffer[0], tmp, 1024))
 	nod.SetString(std::string(&buffer[0]));
       else
 	nod.SetString(std::string(tmp));

--- a/src/configuration/resolve_path.cpp
+++ b/src/configuration/resolve_path.cpp
@@ -6,9 +6,10 @@
 #include		<unistd.h>
 #include		"lapin_private.h"
 
-const char		*bunny_configuration_resolve_path(const char	*file)
+bool			bunny_configuration_resolve_path(const char	*file,
+							 char		*buffer,
+							 int		size_buffer)
 {
-  static char		buffer[1024];
   std::list<std::string>::reverse_iterator it;
 
   for (it = SmallConf::file_path.rbegin(); it != SmallConf::file_path.rend(); ++it)
@@ -16,13 +17,13 @@ const char		*bunny_configuration_resolve_path(const char	*file)
       size_t		siz;
 
       if (*it != "")
-	siz = snprintf(&buffer[0], sizeof(buffer), "%s/%s", it->c_str(), file);
+	siz = snprintf(&buffer[0], size_buffer, "%s/%s", it->c_str(), file);
       else
-	siz = snprintf(&buffer[0], sizeof(buffer), "%s", file);
-      if (siz == sizeof(buffer))
+	siz = snprintf(&buffer[0], size_buffer, "%s", file);
+      if (siz == size_buffer)
 	continue ;
       if (access(&buffer[0], R_OK) == 0)
-	return (&buffer[0]);
+	return (true);
     }
-  return (NULL);
+  return (false);
 }


### PR DESCRIPTION
Mise à jour de mergeconf pour supporter l'option -I et pouvoir ajouter des paths supplémentaires à la compilation des dabsics.
Mise à jour de bunny_configuration_resolve_path() pour adapter la valeur de retour globale à une solution par pointeur dans les paramètres. Désormais la fonction retourne un booléan annonçant si vrai ou faux elle a réussit.